### PR TITLE
Add a concurrent mode safe version of useRefs

### DIFF
--- a/src/hooks/ZachHaber/useRefsSafe.ts
+++ b/src/hooks/ZachHaber/useRefsSafe.ts
@@ -1,9 +1,9 @@
 import type * as React from 'react'
+import {useLayoutEffect} from 'react'
 import {useRef, useState} from 'react'
 
 const refsSymbol = Symbol('refs')
 type AcceptedRef<T> = React.MutableRefObject<T> | React.LegacyRef<T>
-
 function applyRefValue<T>(ref: AcceptedRef<T>, value: T | null) {
   if (typeof ref === 'function') {
     ref(value)
@@ -13,62 +13,62 @@ function applyRefValue<T>(ref: AcceptedRef<T>, value: T | null) {
 }
 
 /**
- * `useRefs` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
+ * `useRefsSafe` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
  * The returned object will persist for the full lifetime of the component.
  *
  * This is generally equivalent to `useRef` with the added benefit to keep other refs in sync with this one
  *
- * Note that `useRefs()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
+ * Note that `useRefsSafe()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
  * @param initialValue The initial value for the ref. If it's `null` or `undefined`, the initially provided refs won't be updated with it
  * @param refs Optional refs array to keep updated with this ref
  * @returns Mutable Ref object to allow both reading and manipulating the ref from this hook.
  */
-export function useRefs<T>(
+export function useRefsSafe<T>(
   initialValue: T,
   refs?: Array<AcceptedRef<T>>,
 ): React.MutableRefObject<T>
 /**
- * `useRefs` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
+ * `useRefsSafe` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
  * The returned object will persist for the full lifetime of the component.
  *
  * This is generally equivalent to `useRef` with the added benefit to keep other refs in sync with this one
  *
- * Note that `useRefs()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
+ * Note that `useRefsSafe()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
  * @param initialValue The initial value for the ref. If it's `null` or `undefined`, the initially provided refs won't be updated with it
  * @param refs Optional refs array to keep updated with this ref
  * @returns Mutable Ref object to allow both reading and manipulating the ref from this hook.
  */
-export function useRefs<T>(
+export function useRefsSafe<T>(
   initialValue: T | null,
   refs?: Array<AcceptedRef<T | null>>,
 ): React.RefObject<T>
 /**
- * `useRefs` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
+ * `useRefsSafe` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
  * The returned object will persist for the full lifetime of the component.
  *
  * This is generally equivalent to `useRef` with the added benefit to keep other refs in sync with this one
  *
- * Note that `useRefs()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
+ * Note that `useRefsSafe()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
  * @param initialValue The initial value for the ref. If it's `null` or `undefined`, the initially provided refs won't be updated with it
  * @param refs Optional refs array to keep updated with this ref
  * @returns Mutable Ref object to allow both reading and manipulating the ref from this hook.
  */
-export function useRefs<T = undefined>(
+export function useRefsSafe<T = undefined>(
   initialValue?: undefined,
   refs?: Array<AcceptedRef<T | undefined>>,
 ): React.RefObject<T | undefined>
 /**
- * `useRefs` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
+ * `useRefsSafe` returns a mutable ref object whose .current property is initialized to the passed argument (initialValue).
  * The returned object will persist for the full lifetime of the component.
  *
  * This is generally equivalent to `useRef` with the added benefit to keep other refs in sync with this one
  *
- * Note that `useRefs()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
+ * Note that `useRefsSafe()` is useful for more than the ref attribute. It’s handy for keeping any mutable value around similar to how you’d use instance fields in classes.
  * @param initialValue The initial value for the ref. If it's `null` or `undefined`, the initially provided refs won't be updated with it
  * @param refs Optional refs array to keep updated with this ref
  * @returns Mutable Ref object to allow both reading and manipulating the ref from this hook.
  */
-export function useRefs<T>(
+export function useRefsSafe<T>(
   initialValue: T,
   refs?: Array<AcceptedRef<T>>,
 ): React.MutableRefObject<T> {
@@ -82,7 +82,7 @@ export function useRefs<T>(
     const proxy = new Proxy(refToProxy, {
       set(target, p, value, receiver) {
         if (p === 'current') {
-          target[refsSymbol].forEach(ref => {
+          target[refsSymbol]?.forEach(ref => {
             applyRefValue(ref, value)
           })
         } else if (p === refsSymbol && Array.isArray(value)) {
@@ -112,9 +112,10 @@ export function useRefs<T>(
     })
     return proxy
   })
-  // ensure the refs is always an array
   // Update the current refs on each render
-  // Refs are mutable and thus a bit
-  proxiedRef[refsSymbol] = refs || []
+  // useImperativeHandle has the same timing as useLayoutEffect, unfortunately
+  useLayoutEffect(() => {
+    proxiedRef[refsSymbol] = refs || []
+  }, [refs])
   return proxiedRef
 }

--- a/src/hooks/index.test.jsx
+++ b/src/hooks/index.test.jsx
@@ -6,6 +6,7 @@ import {useMergedRefs2} from './agriffis/useMergedRefs2'
 import useReflector from './agriffis/useReflector'
 import {useMergeRefs} from './use-callback-ref'
 import {useRefs} from './ZachHaber/useRefs'
+import {useRefsSafe} from './ZachHaber/useRefsSafe'
 
 describe.each([
   ['agriffis/useMergedRefs', useMergedRefs],
@@ -13,6 +14,7 @@ describe.each([
   ['agriffis/useReflector', useReflector],
   ['use-callback-ref', useMergeRefs],
   ['ZachHaber/useRefs', refs => useRefs(undefined, refs)],
+  ['ZachHaber/useRefsSafe', refs => useRefsSafe(undefined, refs)],
 ])('%s', (_, useX) => {
   test('works with zero refs', async () => {
     const TestMe = () => {


### PR DESCRIPTION
Only difference is that refs are applied at the same time as layoutEffects, so its slower to apply.

I thought I had a good solution for fixing the concurrent mode issue _and_ keeping the ability to work with layoutEffects. Unfortunately, `useImperativeHandle` [runs at the same timing](https://github.com/facebook/react/blob/c91a1e03be54733a7dbfcb5663d7a9e8606ab1c1/packages/react-reconciler/src/ReactFiberHooks.new.js#L1995) as `useLayoutEffect`, so in this case it would just require more boilerplate for no improvement over a layoutEffect.

Theoretically, if I set the proxiedRef to have the current refs on first mount, as long as you don't change the refs, it will work for layout effects, but I think it might make sense to either make it always work for layout effect (probably not safe for concurrent mode) or make it always _not_ work for layout effects (probably safer for concurrent mode).

If the React team changes the timing of `useImperativeEffect` to be at the same time as the normal DOM ref setting, then I think we could get it fully settled in user-land, but I think it would still be better and safer for them to just make refs merge automatically in the library.